### PR TITLE
Expand the map to fill the screen

### DIFF
--- a/client/components/home/UserInput/Location/index.tsx
+++ b/client/components/home/UserInput/Location/index.tsx
@@ -68,6 +68,7 @@ export const Location = ({ handleBlur, showText }: LocationProps) => {
 				styles={{
 					control: (base) => ({
 						...base,
+						overflow: "hidden",
 						borderColor: showEmptyWarning ? COLORS.Select.error : COLORS.gray[200],
 					}),
 					menu: (base) => ({

--- a/client/components/map/LeafletMap.tsx
+++ b/client/components/map/LeafletMap.tsx
@@ -3,7 +3,6 @@ import { MapContainer, TileLayer } from "react-leaflet";
 import { LatLngExpression, MapOptions } from "leaflet";
 import { useState, useEffect } from "react";
 import useMapContext from "../../hooks/useMapContext";
-import { useBreakpointValue } from "@chakra-ui/react";
 import "leaflet/dist/leaflet.css";
 
 export const LeafletMap: React.FC<
@@ -19,15 +18,15 @@ export const LeafletMap: React.FC<
 	useEffect(() => {
 		setIsClient(true);
 	}, []);
-	const isMobile = useBreakpointValue({ base: true, md: false });
 
 	return (
 		<>
 			{isClient && (
 				<MapContainer
-					style={{ height: `${isMobile ? "70vh" : "80vh"}`, width: "100%" }}
+					style={{ height: "100%", width: "100%" }}
 					ref={(e) => setMap && setMap(e || undefined)}
 					className="w-full h-screen absolute outline-0 text-white"
+					zoomControl={false}
 					{...options}
 				>
 					<TileLayer url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png" />

--- a/client/spa-pages/components/MapPage.tsx
+++ b/client/spa-pages/components/MapPage.tsx
@@ -301,14 +301,62 @@ const MapInner = ({ setPage }: Props) => {
 
 	return (
 		<BasePage title="Instructions" description="Singapore's first recycling planner">
-			<Container
-				maxW={{
-					base: "full",
-					sm: "container.md",
-				}}
-				ref={viewportRef}
-			>
-				<VStack spacing={3} align="stretch">
+			<Box height="calc(100vh - 80px)" position="relative">
+				{/* Map Display */}
+				<Box
+					transition="opacity 0.3s"
+					opacity={isLoading ? 0 : 1}
+					onClick={() => setFacCardIsOpen(false)}
+					position="absolute"
+					height="100%"
+					width="100%"
+					left={0}
+					top={0}
+					zIndex={0}
+				>
+					<LeafletMap center={centerPos} zoom={zoom} minZoom={11} maxZoom={18}>
+						{/* The color is the background color of the cluster */}
+						<Cluster icon={ClusterIcon} color={"#81C784"} chunkedLoading>
+							{locations &&
+								// ClothingType will be used to show relevant icon
+								Object.entries(locations).map(([category, result]) => {
+									return result.facilities.map((facility) => {
+										return (
+											<CustomMarker
+												key={facility.id}
+												position={facility.latlng as LatLngExpression}
+												icon={GeneralIcon}
+												color={"#FFFFFF"}
+												handleOnClick={() => handleMarkerOnClick(facility)}
+												category={category}
+											/>
+										);
+									});
+								})}
+						</Cluster>
+						{/* Center Marker */}
+						<CustomMarker
+							position={centerPos}
+							icon={UserIcon}
+							color={"#FF0000"}
+							handleOnClick={() => setFacCardIsOpen(false)}
+						/>
+					</LeafletMap>
+				</Box>
+
+				<VStack
+					width="100%"
+					maxW={{
+						base: "full",
+						sm: "container.md",
+					}}
+					spacing={3}
+					align="stretch"
+					position="absolute"
+					left="50%"
+					transform="translate(-50%, 0)"
+					paddingX={4}
+				>
 					{/* Header Buttons */}
 					<HeaderButtons setPage={setPage} />
 					<Flex w="100%" direction={"row"} gap={"0.3rem"}>
@@ -332,70 +380,25 @@ const MapInner = ({ setPage }: Props) => {
 							}),
 						}}
 					/>
-
-					{/* Map Display */}
-					<Box
-						transition="opacity 0.3s"
-						opacity={isLoading ? 0 : 1}
-						onClick={() => setFacCardIsOpen(false)}
-						position="absolute"
-						top="80px"
-						left={0}
-						width="100vw"
-						height="calc(100vh - 80px)"
-						zIndex="-1"
-					>
-						<LeafletMap center={centerPos} zoom={zoom} minZoom={11} maxZoom={18}>
-							{/* The color is the background color of the cluster */}
-							<Cluster icon={ClusterIcon} color={"#81C784"} chunkedLoading>
-								{locations &&
-									// ClothingType will be used to show relevant icon
-									Object.entries(locations).map(([category, result]) => {
-										return result.facilities.map((facility) => {
-											return (
-												<CustomMarker
-													key={facility.id}
-													position={facility.latlng as LatLngExpression}
-													icon={GeneralIcon}
-													color={"#FFFFFF"}
-													handleOnClick={() =>
-														handleMarkerOnClick(facility)
-													}
-													category={category}
-												/>
-											);
-										});
-									})}
-							</Cluster>
-							{/* Center Marker */}
-							<CustomMarker
-								position={centerPos}
-								icon={UserIcon}
-								color={"#FF0000"}
-								handleOnClick={() => setFacCardIsOpen(false)}
-							/>
-						</LeafletMap>
-					</Box>
-
-					{/* Facility Card */}
-					{facCardIsOpen &&
-						(isMobile ? (
-							<FacilityCard
-								facCardDetails={facCardDetails}
-								facCardDistance={facCardDistance}
-								width={"86%"}
-								left={"7%"}
-							/>
-						) : (
-							<FacilityCard
-								facCardDetails={facCardDetails}
-								facCardDistance={facCardDistance}
-								width={"50%"}
-								left={"25%"}
-							/>
-						))}
 				</VStack>
-			</Container>
+
+				{facCardIsOpen &&
+					(isMobile ? (
+						<FacilityCard
+							facCardDetails={facCardDetails}
+							facCardDistance={facCardDistance}
+							width={"86%"}
+							left={"7%"}
+						/>
+					) : (
+						<FacilityCard
+							facCardDetails={facCardDetails}
+							facCardDistance={facCardDistance}
+							width={"50%"}
+							left={"25%"}
+						/>
+					))}
+			</Box>
 
 			{/* Keeping this for future implementations of similar idea */}
 			{/* Pull up tab */}

--- a/client/spa-pages/components/MapPage.tsx
+++ b/client/spa-pages/components/MapPage.tsx
@@ -332,51 +332,49 @@ const MapInner = ({ setPage }: Props) => {
 							}),
 						}}
 					/>
+
 					{/* Map Display */}
-					<Box overflow="hidden" width="100%" height={isMobile ? "70vh" : "80vh"}>
-						<Box
-							left={0}
-							transition="opacity 0.3s"
-							opacity={isLoading ? 0 : 1}
-							top={80}
-							// This was in the reference code
-							width={viewportWidth ?? "100%"}
-							height={viewportHeight ? viewportHeight - 80 : "100%"}
-							onClick={() => setFacCardIsOpen(false)}
-						>
-							<LeafletMap center={centerPos} zoom={zoom} minZoom={11} maxZoom={18}>
-								{/* The color is the background color of the cluster */}
-								<Cluster icon={ClusterIcon} color={"#81C784"} chunkedLoading>
-									{locations &&
-										// ClothingType will be used to show relevant icon
-										Object.entries(locations).map(([category, result]) => {
-											return result.facilities.map((facility) => {
-												return (
-													<CustomMarker
-														key={facility.id}
-														position={
-															facility.latlng as LatLngExpression
-														}
-														icon={GeneralIcon}
-														color={"#FFFFFF"}
-														handleOnClick={() =>
-															handleMarkerOnClick(facility)
-														}
-														category={category}
-													/>
-												);
-											});
-										})}
-								</Cluster>
-								{/* Center Marker */}
-								<CustomMarker
-									position={centerPos}
-									icon={UserIcon}
-									color={"#FF0000"}
-									handleOnClick={() => setFacCardIsOpen(false)}
-								/>
-							</LeafletMap>
-						</Box>
+					<Box
+						transition="opacity 0.3s"
+						opacity={isLoading ? 0 : 1}
+						onClick={() => setFacCardIsOpen(false)}
+						position="absolute"
+						top="80px"
+						left={0}
+						width="100vw"
+						height="calc(100vh - 80px)"
+						zIndex="-1"
+					>
+						<LeafletMap center={centerPos} zoom={zoom} minZoom={11} maxZoom={18}>
+							{/* The color is the background color of the cluster */}
+							<Cluster icon={ClusterIcon} color={"#81C784"} chunkedLoading>
+								{locations &&
+									// ClothingType will be used to show relevant icon
+									Object.entries(locations).map(([category, result]) => {
+										return result.facilities.map((facility) => {
+											return (
+												<CustomMarker
+													key={facility.id}
+													position={facility.latlng as LatLngExpression}
+													icon={GeneralIcon}
+													color={"#FFFFFF"}
+													handleOnClick={() =>
+														handleMarkerOnClick(facility)
+													}
+													category={category}
+												/>
+											);
+										});
+									})}
+							</Cluster>
+							{/* Center Marker */}
+							<CustomMarker
+								position={centerPos}
+								icon={UserIcon}
+								color={"#FF0000"}
+								handleOnClick={() => setFacCardIsOpen(false)}
+							/>
+						</LeafletMap>
 					</Box>
 
 					{/* Facility Card */}


### PR DESCRIPTION
Resolves https://github.com/bettersg/recyclegowhere/issues/166

- Expand the map to fill the screen
- Display controls over it
- Hide the zoom control to match the Figma designs
- Hide overflow on the search bar when long addresses are entered

<table>
<tr>
 <td>Mobile
 <td>Tablet
 <td>Desktop
<tr>
 <td><img src="https://github.com/bettersg/recyclegowhere/assets/5859290/ea28f340-edbd-4bbe-835c-b3467347a5ce"/>
 <td><img src="https://github.com/bettersg/recyclegowhere/assets/5859290/6f9081c2-cb72-4953-8950-c27bba8b05f2"/>
 <td><img src="https://github.com/bettersg/recyclegowhere/assets/5859290/207f3f21-ca93-4d1e-972c-54353206d71c"/>
</table>



